### PR TITLE
Fix go path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/clems4ever/haproxy-spoe-auth
+module github.com/criteo/haproxy-spoe-auth
 
 go 1.15
 


### PR DESCRIPTION
This should fix this
```
go get -v github.com/criteo/haproxy-spoe-auth@master:
#7 1.060 go: downloading github.com/criteo/haproxy-spoe-auth v0.0.0-20210215105522-d4abff4d3d37
#7 1.207 go get: github.com/criteo/haproxy-spoe-auth@none updating to
#7 1.207 	github.com/criteo/haproxy-spoe-auth@v0.0.0-20210215105522-d4abff4d3d37: parsing go.mod:
#7 1.207 	module declares its path as: github.com/clems4ever/haproxy-spoe-auth
#7 1.207 	        but was required as: github.com/criteo/haproxy-spoe-auth
```