### PR TITLE
Add an http healthcheck to the OIDC module

### DIFF
--- a/cmd/haproxy-spoe-auth/main.go
+++ b/cmd/haproxy-spoe-auth/main.go
@@ -67,6 +67,7 @@ func main() {
 			OAuth2AuthenticatorOptions: auth.OAuth2AuthenticatorOptions{
 				RedirectCallbackPath: viper.GetString("oidc.oauth2_callback_path"),
 				LogoutPath:           viper.GetString("oidc.oauth2_logout_path"),
+				HealthCheckPath:      viper.GetString("oidc.oauth2_healthcheck_path"),
 				CallbackAddr:         viper.GetString("oidc.callback_addr"),
 				CookieName:           viper.GetString("oidc.cookie_name"),
 				CookieSecure:         viper.GetBool("oidc.cookie_secure"),

--- a/internal/auth/authenticator_oidc.go
+++ b/internal/auth/authenticator_oidc.go
@@ -38,6 +38,7 @@ type OAuth2AuthenticatorOptions struct {
 	Endpoints            oauth2.Endpoint
 	RedirectCallbackPath string
 	LogoutPath           string
+	HealthCheckPath      string
 
 	// This is used to sign the redirection URL
 	SignatureSecret string
@@ -107,10 +108,15 @@ func NewOIDCAuthenticator(options OIDCAuthenticatorOptions) *OIDCAuthenticator {
 		http.HandleFunc(options.RedirectCallbackPath, oa.handleOAuth2Callback(tmpl, errorTmpl))
 		http.HandleFunc(options.LogoutPath, oa.handleOAuth2Logout())
 		logrus.Infof("OIDC API is exposed on %s", options.CallbackAddr)
+		http.HandleFunc(options.HealthCheckPath, handleHealthCheck)
 		http.ListenAndServe(options.CallbackAddr, nil)
 	}()
 
 	return oa
+}
+
+func handleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("OK"))
 }
 
 func (oa *OIDCAuthenticator) withOAuth2Config(domain string, callback func(c oauth2.Config) error) error {

--- a/resources/configuration/config.yml
+++ b/resources/configuration/config.yml
@@ -26,6 +26,8 @@ oidc:
   oauth2_callback_path: /oauth2/callback
   # The path to the logout endpoint to redirect the user to.
   oauth2_logout_path: /oauth2/logout
+  # The path the oidc client uses for a healthcheck
+  oauth2_healthcheck_path: /health
   # The SPOE agent will open a dedicated port for the HTTP server handling the callback. This is the address the server listens on
   callback_addr: ":5000"
 


### PR DESCRIPTION
This will allow us to check if the OIDC module is up and ready to deal with requests.
The health of the agent can already be checked via a TCP check.