### PR TITLE
Support group authorization for ldap

### DIFF
--- a/docs/ldap.md
+++ b/docs/ldap.md
@@ -1,5 +1,10 @@
 # LDAP Authentication
 
+The following spoa message string will be replaced in ldap search query, when provided
+    - {user}; represent the user to match
+    - {group}: represent the group to which belongs the user
+An example of user query is provided, but has to be adapated following the LDAP implementation.
+
 ## TODO
 
 This agent is currently experimental and under active development. I would not advise to run it in

--- a/resources/configuration/config.yml
+++ b/resources/configuration/config.yml
@@ -15,7 +15,7 @@ ldap:
   # The base DN used for the search queries 
   base_dn: dc=example,dc=com
   # The filter for the query searching for the user provided
-  user_filter: "(cn={login})"
+  user_filter: "(&(cn={login})(ou:dn:={group}))"
 
 # If set, the OpenID Connect authenticator is enabled
 oidc:

--- a/resources/haproxy/spoe-auth.conf
+++ b/resources/haproxy/spoe-auth.conf
@@ -12,7 +12,7 @@ spoe-agent auth-agents
     use-backend backend_spoe-agent
 
 spoe-message try-auth-ldap
-    args authorization=req.hdr(Authorization)
+    args authorization=req.hdr(Authorization) authorized_group=str(users)
     event on-frontend-http-request if { hdr_beg(host) -i app1.example.com } || { hdr_beg(host) -i app2.example.com } || { hdr_beg(host) -i app3.example.com }
 
 spoe-message try-auth-oidc

--- a/resources/ldap/01-base.ldif
+++ b/resources/ldap/01-base.ldif
@@ -8,6 +8,11 @@ objectclass: organizationalUnit
 objectclass: top
 ou: users
 
+dn: ou=users2,dc=example,dc=com
+objectclass: organizationalUnit
+objectclass: top
+ou: users2
+
 dn: cn=dev,ou=groups,dc=example,dc=com
 cn: dev
 member: cn=john,ou=users,dc=example,dc=com
@@ -34,4 +39,12 @@ objectclass: inetOrgPerson
 objectclass: top
 mail: harry.potter@example.com
 sn: Harry Potter
+userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+
+dn: cn=barry,ou=users2,dc=example,dc=com
+cn: barry
+objectclass: inetOrgPerson
+objectclass: top
+mail: barry.allen@example.com
+sn: Barry Allen
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/

--- a/tests/ldap_authentication_test.go
+++ b/tests/ldap_authentication_test.go
@@ -29,6 +29,17 @@ func TestShouldFailAuthenticationInLDAP(t *testing.T) {
 	assert.Equal(t, 401, res.StatusCode)
 }
 
+func TestShouldFailAuthenticationInLDAPWrongGroup(t *testing.T) {
+	req, err := http.NewRequest("GET", App1URL, nil)
+	assert.NoError(t, err)
+	req.SetBasicAuth("barry", "password")
+
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 401, res.StatusCode)
+}
+
 func TestShouldFailWhenNoCredsProvided(t *testing.T) {
 	req, err := http.NewRequest("GET", App1URL, nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
When group is provided to spoa agent by HAProxy, use it in user filter query to look up for the user in ldap.
The user filter also has to be updated to contain the string "{group}" in the user filter.