### PR TITLE
Retrieve client information from spoe message

### DIFF
--- a/internal/auth/oidc_clients_store.go
+++ b/internal/auth/oidc_clients_store.go
@@ -1,5 +1,9 @@
 package auth
 
+import (
+	"strings"
+)
+
 type OIDCClientConfig struct {
 	ClientID     string `mapstructure:"client_id"`
 	ClientSecret string `mapstructure:"client_secret"`
@@ -9,6 +13,7 @@ type OIDCClientConfig struct {
 type OIDCClientsStore interface {
 	// Retrieve the client_id and client_secret based on the domain
 	GetClient(domain string) (*OIDCClientConfig, error)
+	AddClient(domain string, clientid string, clientsecret string, redirecturl string)
 }
 
 type StaticOIDCClientsStore struct {
@@ -19,9 +24,23 @@ func NewStaticOIDCClientStore(config map[string]OIDCClientConfig) *StaticOIDCCli
 	return &StaticOIDCClientsStore{clients: config}
 }
 
+func NewEmptyStaticOIDCClientStore() *StaticOIDCClientsStore {
+	return &StaticOIDCClientsStore{clients: map[string]OIDCClientConfig{}}
+}
+
 func (ocf *StaticOIDCClientsStore) GetClient(domain string) (*OIDCClientConfig, error) {
 	if config, ok := ocf.clients[domain]; ok {
 		return &config, nil
 	}
 	return nil, ErrOIDCClientConfigNotFound
+}
+
+func (ocf *StaticOIDCClientsStore) AddClient(domain string, clientid string, clientsecret string, redirecturl string) {
+	if _, ok := ocf.clients[domain]; !ok {
+		ocf.clients[strings.Clone(domain)] = OIDCClientConfig {
+			ClientID: strings.Clone(clientid),
+			ClientSecret: strings.Clone(clientsecret),
+			RedirectURL: strings.Clone(redirecturl),
+		}
+	}
 }

--- a/resources/configuration/config.yml
+++ b/resources/configuration/config.yml
@@ -44,11 +44,7 @@ oidc:
 
   # A mapping of client credentials per protected domain
   clients:
-    app2.example.com:
-      client_id: app2-client
-      client_secret: app2-secret
-      redirect_url: http://app2.example.com:9080/oauth2/callback
-    app3.example.com:
-      client_id: app3-client
-      client_secret: app3-secret
-      redirect_url: http://app3.example.com:9080/oauth2/callback
+    dummy.example.com:
+      client_id: dummy-client
+      client_secret: dummy-secret
+      redirect_url: http://dummy.example.com:9080/oauth2/callback

--- a/resources/haproxy/haproxy.cfg
+++ b/resources/haproxy/haproxy.cfg
@@ -22,13 +22,23 @@ frontend haproxynode
     # Domains to protect
     acl acl_public hdr_beg(host) -i public.example.com
     acl acl_app1 hdr_beg(host) -i app1.example.com
+
     acl acl_app2 hdr_beg(host) -i app2.example.com
+    http-request set-var(req.oidc_client_id) str(app2-client) if acl_app2
+    http-request set-var(req.oidc_client_secret) str(app2-secret) if acl_app2
+    http-request set-var(req.oidc_redirect_url) str(http://app2.example.com:9080/oauth2/callback) if acl_app2
+
     acl acl_app3 hdr_beg(host) -i app3.example.com
+    http-request set-var(req.oidc_client_id) str(app3-client) if acl_app3
+    http-request set-var(req.oidc_client_secret) str(app3-secret) if acl_app3
+    http-request set-var(req.oidc_redirect_url) str(http://app3.example.com:9080/oauth2/callback) if acl_app3
+
     acl oauth2callback path_beg /oauth2/callback
     acl oauth2logout path_beg /oauth2/logout
 
     acl dex_domain hdr_beg(host) -i dex.example.com
     # define the spoe agent
+    http-request send-spoe-group spoe-auth try-auth-all
     filter spoe engine spoe-auth config /usr/local/etc/haproxy/spoe-auth.conf
 
     # map the spoe response to acl variables

--- a/resources/haproxy/spoe-auth.conf
+++ b/resources/haproxy/spoe-auth.conf
@@ -1,20 +1,22 @@
 [spoe-auth]
 spoe-agent auth-agents
-    messages try-auth-ldap
-    messages try-auth-oidc
-
     option var-prefix auth
 
     timeout hello      2s
     timeout idle       2m
     timeout processing 1s
 
+    groups try-auth-all
     use-backend backend_spoe-agent
+
+spoe-group try-auth-all
+    messages try-auth-ldap
+    messages try-auth-oidc
 
 spoe-message try-auth-ldap
     args authorization=req.hdr(Authorization) authorized_group=str(users)
     event on-frontend-http-request if { hdr_beg(host) -i app1.example.com } || { hdr_beg(host) -i app2.example.com } || { hdr_beg(host) -i app3.example.com }
 
 spoe-message try-auth-oidc
-    args arg_ssl=ssl_fc arg_host=req.hdr(Host) arg_pathq=pathq arg_cookie=req.cook(authsession)
+    args arg_ssl=ssl_fc arg_host=req.hdr(Host) arg_pathq=pathq arg_cookie=req.cook(authsession) arg_client_id=var(req.oidc_client_id) arg_client_secret=var(req.oidc_client_secret) arg_redirect_url=var(req.oidc_redirect_url)
     event on-frontend-http-request if { hdr_beg(host) -i app1.example.com } || { hdr_beg(host) -i app2.example.com } || { hdr_beg(host) -i app3.example.com }

--- a/resources/scripts/run.sh
+++ b/resources/scripts/run.sh
@@ -4,12 +4,12 @@ if [[ "$DEBUG_ENABLED" -eq "1" ]]
 then
     echo "Running agent along with debug server"
     /scripts/run-with-debug.sh haproxy-spoe-auth cmd/haproxy-spoe-auth/main.go -- \
-        -config /configuration/config.yml
+        -config /configuration/config.yml -dynamic-client-info
 else
     while true
     do
         echo "Running agent without debug server"
-        go run cmd/haproxy-spoe-auth/main.go -config /configuration/config.yml
+        go run cmd/haproxy-spoe-auth/main.go -config /configuration/config.yml -dynamic-client-info
         sleep 2
     done
 fi


### PR DESCRIPTION
The client information are statically defined in agent config file. Goal of this patch is to be able to send those information directly via the spoe messages, and therefore be able to configure them directly on HAProxy config file.

For the test/docker, since we can run only type of environment, run the one with dynamic client info option enabled.