### PR TITLE
Allow fixing the redirect_url when authenticating requests with different hostnames

### DIFF
--- a/internal/auth/authenticator_oidc.go
+++ b/internal/auth/authenticator_oidc.go
@@ -82,15 +82,15 @@ type OIDCAuthenticator struct {
 }
 
 type OAuthArgs struct {
-	ssl                  bool
-	host                 string
+	ssl                bool
+	host               string
 	oidc_callback_host string
-	pathq                string
-	clientid             string
-	clientsecret         string
-	redirecturl          string
-	cookie               string
-	tokenClaims          []string
+	pathq              string
+	clientid           string
+	clientsecret       string
+	redirecturl        string
+	cookie             string
+	tokenClaims        []string
 }
 
 // NewOIDCAuthenticator create an instance of an OIDC authenticator

--- a/internal/auth/authenticator_oidc.go
+++ b/internal/auth/authenticator_oidc.go
@@ -187,7 +187,7 @@ func (oa *OIDCAuthenticator) decryptCookie(cookieValue string, domain string) (*
 }
 
 func extractOAuth2Args(msg *message.Message, readClientInfoFromMessages bool) (OAuthArgs, error) {
-	var cookie, oidcCallbackDomain string
+	var cookie, oidcCallbackHost string
 	var clientid, clientsecret, redirecturl *string
 	var tokenClaims []string
 

--- a/internal/auth/authenticator_oidc.go
+++ b/internal/auth/authenticator_oidc.go
@@ -66,6 +66,7 @@ type State struct {
 	Timestamp          time.Time
 	Signature          string
 	PathAndQueryString string
+	Host               string
 	SSL                bool
 }
 
@@ -81,14 +82,15 @@ type OIDCAuthenticator struct {
 }
 
 type OAuthArgs struct {
-	ssl          bool
-	host         string
-	pathq        string
-	clientid     string
-	clientsecret string
-	redirecturl  string
-	cookie       string
-	tokenClaims  []string
+	ssl                  bool
+	host                 string
+	oidc_callback_host string
+	pathq                string
+	clientid             string
+	clientsecret         string
+	redirecturl          string
+	cookie               string
+	tokenClaims          []string
 }
 
 // NewOIDCAuthenticator create an instance of an OIDC authenticator
@@ -185,44 +187,50 @@ func (oa *OIDCAuthenticator) decryptCookie(cookieValue string, domain string) (*
 }
 
 func extractOAuth2Args(msg *message.Message, readClientInfoFromMessages bool) (OAuthArgs, error) {
-	var cookie string
+	var cookie, oidcCallbackDomain string
 	var clientid, clientsecret, redirecturl *string
 	var tokenClaims []string
 
 	// ssl
 	sslValue, ok := msg.KV.Get("arg_ssl")
 	if !ok {
-		return OAuthArgs{ssl: false, host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
+		return OAuthArgs{ssl: false, host: "", oidc_callback_host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
 			ErrSSLArgNotFound
 	}
 	ssl, ok := sslValue.(bool)
 	if !ok {
-		return OAuthArgs{ssl: false, host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
+		return OAuthArgs{ssl: false, host: "", oidc_callback_host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
 			fmt.Errorf("SSL is not a bool: %v", sslValue)
 	}
 
 	// host
 	hostValue, ok := msg.KV.Get("arg_host")
 	if !ok {
-		return OAuthArgs{ssl: false, host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
+		return OAuthArgs{ssl: false, host: "", oidc_callback_host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
 			ErrHostArgNotFound
 	}
 	host, ok := hostValue.(string)
 	if !ok {
-		return OAuthArgs{ssl: false, host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
+		return OAuthArgs{ssl: false, host: "", oidc_callback_host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
 			fmt.Errorf("host is not a string: %v", hostValue)
 	}
 
 	// pathq
 	pathqValue, ok := msg.KV.Get("arg_pathq")
 	if !ok {
-		return OAuthArgs{ssl: false, host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
+		return OAuthArgs{ssl: false, host: "", oidc_callback_host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
 			ErrPathqArgNotFound
 	}
 	pathq, ok := pathqValue.(string)
 	if !ok {
-		return OAuthArgs{ssl: false, host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
+		return OAuthArgs{ssl: false, host: "", oidc_callback_host: "", pathq: "", cookie: "", clientid: "", clientsecret: "", redirecturl: ""},
 			fmt.Errorf("pathq is not a string: %v", pathqValue)
+	}
+
+	// oidc_callback_host
+	oidcCallbackHostValue, ok := msg.KV.Get("arg_oidc_callback_host")
+	if ok {
+		oidcCallbackHost, _ = oidcCallbackHostValue.(string)
 	}
 
 	// cookie
@@ -293,7 +301,7 @@ func extractOAuth2Args(msg *message.Message, readClientInfoFromMessages bool) (O
 		temp := ""
 		clientsecret = &temp
 	}
-	return OAuthArgs{ssl: ssl, host: host, pathq: pathq,
+	return OAuthArgs{ssl: ssl, host: host, oidc_callback_host: oidcCallbackDomain, pathq: pathq,
 			cookie: cookie, clientid: *clientid,
 			clientsecret: *clientsecret, redirecturl: *redirecturl,
 			tokenClaims: tokenClaims},
@@ -327,7 +335,11 @@ func (oa *OIDCAuthenticator) Authenticate(msg *message.Message) (bool, []action.
 		return false, nil, fmt.Errorf("unable to extract origin URL: %v", err)
 	}
 
-	domain := extractDomainFromHost(oauthArgs.host)
+	host := oauthArgs.host
+	if oauthArgs.oidc_callback_host != "" {
+		host = oauthArgs.oidc_callback_host
+	}
+	domain := extractDomainFromHost(host)
 
 	if oauthArgs.clientid != "" {
 		oa.options.ClientsStore.AddClient(domain, oauthArgs.clientid, oauthArgs.clientsecret, oauthArgs.redirecturl)
@@ -389,6 +401,7 @@ func (oa *OIDCAuthenticator) buildAuthorizationURL(domain string, oauthArgs OAut
 	state.Timestamp = currentTime
 	state.PathAndQueryString = oauthArgs.pathq
 	state.SSL = oauthArgs.ssl
+	state.Host = oauthArgs.host
 	state.Signature = oa.computeStateSignature(&state)
 
 	stateBytes, err := msgpack.Marshal(state)
@@ -502,7 +515,11 @@ func (oa *OIDCAuthenticator) handleOAuth2Callback(tmpl *template.Template, error
 		if !state.SSL {
 			scheme = "http"
 		}
-		url := fmt.Sprintf("%s://%s%s", scheme, r.Host, state.PathAndQueryString)
+		destination_host := state.Host
+		if destination_host == "" {
+			destination_host = r.Host
+		}
+		url := fmt.Sprintf("%s://%s%s", scheme, destination_host, state.PathAndQueryString)
 		logrus.Debugf("target url request by user %s", url)
 		signature := oa.computeStateSignature(&state)
 		if signature != state.Signature {
@@ -536,6 +553,7 @@ func (oa *OIDCAuthenticator) handleOAuth2Callback(tmpl *template.Template, error
 			Value:    encryptedIDToken,
 			Path:     "/",
 			Expires:  expiry,
+			Domain:   destination_host,
 			HttpOnly: true,
 			Secure:   oa.options.CookieSecure,
 		}

--- a/internal/auth/authenticator_oidc.go
+++ b/internal/auth/authenticator_oidc.go
@@ -301,7 +301,7 @@ func extractOAuth2Args(msg *message.Message, readClientInfoFromMessages bool) (O
 		temp := ""
 		clientsecret = &temp
 	}
-	return OAuthArgs{ssl: ssl, host: host, oidc_callback_host: oidcCallbackDomain, pathq: pathq,
+	return OAuthArgs{ssl: ssl, host: host, oidc_callback_host: oidcCallbackHost, pathq: pathq,
 			cookie: cookie, clientid: *clientid,
 			clientsecret: *clientsecret, redirecturl: *redirecturl,
 			tokenClaims: tokenClaims},


### PR DESCRIPTION
Currently, the behavior of the oidc authenticator is that:

1. If a request with hostname `example.com` is sent to the agent, it will use the hostname to fetch the OIDC client from the statically defined config or register a new one under that hostname if `arg_{client_id, client_secret, redirect_url}`. 
2. Then the redirect URL is built, in this case it will be `example.com/oauth2/callback`.
3. On the OIDC response the agent will issue a redirect to `example.com` to set the cookie on the client brower.
4. The redirect URL will change with different hostname, and the agent assumes that the hostname of the original destination is the hostname in the callback URL.

**While this is fine for single hostname, when haproxy is serving incoming request with a lot of different hostnames the list of allowed redirect URLs that needs to be configured will need to be updated constantly on the IDP side which is not ideal. Some IDPs also only allow one set of credential per redirect URL.**

This PR tries to provide a solution for cases like that where the redirect URL can be set to a fixed value regardless of the hostname of the incoming request. The client's original destination is now embeded into the state and used in the final redirect to set the client cookie. The flow now will be something like this:

```
--> client requests example.com 
--> redirect to ( <idp URL>?redirect_url=auth.example.com/oauth2/callback&state=...(contains original destination) ) 
--> auth.example.com/oauth2/callback 
--> redirect to example.com with set-cookie
```